### PR TITLE
feat: use id to find managed ADD server

### DIFF
--- a/modules/base/main.tf
+++ b/modules/base/main.tf
@@ -5,7 +5,9 @@ locals {
 data "azurerm_subscription" "main" {}
 
 data "azuread_service_principal" "aks" {
-  display_name = "Azure Kubernetes Service AAD Server"
+  # The ID of the managed "Azure Kubernetes Service AAD Server" application
+  # https://learn.microsoft.com/en-us/azure/aks/kubelogin-authentication#how-to-use-kubelogin-with-aks
+  client_id = "6dae42f8-4368-4678-94ff-3960e28e3630"
 }
 
 resource "azuread_group" "cluster_admins" {


### PR DESCRIPTION
Use the ID is probably more reliable than relying on the name.