### PR TITLE
fix: references to EKS / EC2 instead of AKS / Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Check for the existence of key elements of the reference architecture. This is a
    export HUMANITEC_ORG="my-humanitec-org"
    ```
 
-2. Verify the existence of the Resource Definition for the EKS cluster in your Humanitec Organization:
+2. Verify the existence of the Resource Definition for the AKS cluster in your Humanitec Organization:
 
    ```
    curl -s https://api.humanitec.io/orgs/${HUMANITEC_ORG}/resources/defs/ref-arch \
@@ -216,7 +216,7 @@ Once you are finished with the reference architecture, you can remove all provis
 | humanitec\_org\_id | Humanitec Organization ID | `string` | n/a | yes |
 | location | Azure region to deploy into | `string` | n/a | yes |
 | subscription\_id | Azure Subscription (ID) to use | `string` | n/a | yes |
-| vm\_size | List of EC2 instances types to use for EKS nodes | `string` | `"Standard_D2_v2"` | no |
+| vm\_size | The Azure VM instances type to use as "Agents" (aka Kubernetes Nodes) in AKS | `string` | `"Standard_D2_v2"` | no |
 <!-- END_TF_DOCS -->
 
 ## Learn more

--- a/modules/base/README.md
+++ b/modules/base/README.md
@@ -57,12 +57,12 @@ Module that provides the reference architecture.
 |------|-------------|------|---------|:--------:|
 | <a name="input_location"></a> [location](#input\_location) | Azure region to deploy into | `string` | n/a | yes |
 | <a name="input_subscription_id"></a> [subscription\_id](#input\_subscription\_id) | Azure Subscription (ID) to use | `string` | n/a | yes |
-| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name for the EKS cluster | `string` | `"ref-arch"` | no |
+| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name for the AKS cluster | `string` | `"ref-arch"` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Name of the environment to be deployed into | `string` | `"development"` | no |
 | <a name="input_ingress_nginx_min_unavailable"></a> [ingress\_nginx\_min\_unavailable](#input\_ingress\_nginx\_min\_unavailable) | Number of allowed unavaiable replicas for the ingress-nginx controller | `number` | `1` | no |
 | <a name="input_ingress_nginx_replica_count"></a> [ingress\_nginx\_replica\_count](#input\_ingress\_nginx\_replica\_count) | Number of replicas for the ingress-nginx controller | `number` | `2` | no |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | Name of the resource group to create | `string` | `"ref-arch"` | no |
-| <a name="input_vm_size"></a> [vm\_size](#input\_vm\_size) | List of EC2 instances types to use for EKS nodes | `string` | `"Standard_D2_v2"` | no |
+| <a name="input_vm_size"></a> [vm\_size](#input\_vm\_size) | The Azure VM instances type to use as "Agents" (aka Kubernetes Nodes) in AKS | `string` | `"Standard_D2_v2"` | no |
 
 ## Outputs
 

--- a/modules/base/variables.tf
+++ b/modules/base/variables.tf
@@ -16,13 +16,13 @@ variable "resource_group_name" {
 }
 
 variable "cluster_name" {
-  description = "Name for the EKS cluster"
+  description = "Name for the AKS cluster"
   type        = string
   default     = "ref-arch"
 }
 
 variable "vm_size" {
-  description = "List of EC2 instances types to use for EKS nodes"
+  description = "The Azure VM instances type to use as \"Agents\" (aka Kubernetes Nodes) in AKS"
   type        = string
   default     = "Standard_D2_v2"
 }

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -8,5 +8,5 @@ location = ""
 # Azure Subscription (ID) to use
 subscription_id = ""
 
-# List of EC2 instances types to use for EKS nodes
+# The Azure VM instances type to use as "Agents" (aka Kubernetes Nodes) in AKS
 vm_size = "Standard_D2_v2"

--- a/variables.tf
+++ b/variables.tf
@@ -15,7 +15,7 @@ variable "humanitec_org_id" {
 }
 
 variable "vm_size" {
-  description = "List of EC2 instances types to use for EKS nodes"
+  description = "The Azure VM instances type to use as \"Agents\" (aka Kubernetes Nodes) in AKS"
   type        = string
   default     = "Standard_D2_v2"
 }


### PR DESCRIPTION
Some wording changes in README and terraform descriptions.