### PR TITLE
fix: scope the role assignment to resource group

### DIFF
--- a/modules/base/README.md
+++ b/modules/base/README.md
@@ -49,7 +49,6 @@ Module that provides the reference architecture.
 | [humanitec_resource_definition_criteria.k8s_namespace](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/resource_definition_criteria) | resource |
 | [azuread_client_config.current](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/client_config) | data source |
 | [azuread_service_principal.aks](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/service_principal) | data source |
-| [azurerm_subscription.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subscription) | data source |
 
 ## Inputs
 

--- a/modules/base/main.tf
+++ b/modules/base/main.tf
@@ -2,8 +2,6 @@ locals {
   aks_cluster_user_role_name = "Azure Kubernetes Service Cluster User Role"
 }
 
-data "azurerm_subscription" "main" {}
-
 data "azuread_service_principal" "aks" {
   # The ID of the managed "Azure Kubernetes Service AAD Server" application
   # https://learn.microsoft.com/en-us/azure/aks/kubelogin-authentication#how-to-use-kubelogin-with-aks
@@ -74,7 +72,7 @@ resource "azuread_service_principal_password" "humanitec" {
 }
 
 resource "azurerm_role_assignment" "humanitec_cluster_user_role" {
-  scope                = data.azurerm_subscription.main.id
+  scope                = azurerm_resource_group.main.id
   role_definition_name = local.aks_cluster_user_role_name
   principal_id         = azuread_service_principal.humanitec.id
 }


### PR DESCRIPTION
Cluster user role can be scoped to resource group instead of subscription.