### PR TITLE
Update main.tf - humanitec 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Once you are finished with the reference architecture, you can remove all provis
 | azuread | ~> 2.47 |
 | azurerm | ~> 3.87 |
 | helm | ~> 2.12 |
-| humanitec | ~> 0 |
+| humanitec | ~> 1.0 |
 | kubernetes | ~> 2.25 |
 
 ### Modules

--- a/examples/with-backstage/README.md
+++ b/examples/with-backstage/README.md
@@ -87,7 +87,7 @@ Once you are finished with the reference architecture, you can remove all provis
 | terraform | >= 1.3.0 |
 | Azure | ~> 5.17 |
 | github | ~> 5.38 |
-| humanitec | ~> 0.13 |
+| humanitec | ~> 1.0 |
 
 ### Providers
 
@@ -95,7 +95,7 @@ Once you are finished with the reference architecture, you can remove all provis
 |------|---------|
 | Azure | ~> 5.17 |
 | github | ~> 5.38 |
-| humanitec | ~> 0.13 |
+| humanitec | ~> 1.0 |
 
 ### Modules
 

--- a/examples/with-backstage/provider.tf
+++ b/examples/with-backstage/provider.tf
@@ -22,7 +22,7 @@ terraform {
     }
     humanitec = {
       source  = "humanitec/humanitec"
-      version = "~> 0"
+      version = "~> 1.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/main.tf
+++ b/main.tf
@@ -19,7 +19,7 @@ terraform {
     }
     humanitec = {
       source  = "humanitec/humanitec"
-      version = "~> 0"
+      version = "~> 1.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/modules/base/README.md
+++ b/modules/base/README.md
@@ -12,7 +12,7 @@ Module that provides the reference architecture.
 | <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | ~> 2.47 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.87 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.12 |
-| <a name="requirement_humanitec"></a> [humanitec](#requirement\_humanitec) | ~> 0 |
+| <a name="requirement_humanitec"></a> [humanitec](#requirement\_humanitec) | ~> 1.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.5 |
 
 ## Providers

--- a/modules/base/README.md
+++ b/modules/base/README.md
@@ -22,7 +22,7 @@ Module that provides the reference architecture.
 | <a name="provider_azuread"></a> [azuread](#provider\_azuread) | ~> 2.47 |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.87 |
 | <a name="provider_helm"></a> [helm](#provider\_helm) | ~> 2.12 |
-| <a name="provider_humanitec"></a> [humanitec](#provider\_humanitec) | ~> 0 |
+| <a name="provider_humanitec"></a> [humanitec](#provider\_humanitec) | ~> 1.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.5 |
 
 ## Modules

--- a/modules/base/providers.tf
+++ b/modules/base/providers.tf
@@ -18,7 +18,7 @@ terraform {
     }
     humanitec = {
       source  = "humanitec/humanitec"
-      version = "~> 0"
+      version = "~> 1.0"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
Otherwise `make validate` will fail with:
```
│ Error: Failed to query available provider packages
│ 
│ Could not retrieve the list of available versions for provider
│ humanitec/humanitec: no available releases match the given constraints ~>
│ 0.13, ~> 1.0
╵

Error: Terraform exited with code 1.
make: *** [Makefile:24: validate-./examples/with-backstage] Error 1
```