### PR TITLE
feat: use resource account

### DIFF
--- a/modules/base/README.md
+++ b/modules/base/README.md
@@ -46,6 +46,7 @@ Module that provides the reference architecture.
 | [azurerm_role_assignment.humanitec_cluster_admin_permissions](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.humanitec_cluster_user](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [helm_release.ingress_nginx](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
+| [humanitec_resource_account.cluster_account](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/resource_account) | resource |
 | [humanitec_resource_definition.k8s_cluster_driver](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/resource_definition) | resource |
 | [humanitec_resource_definition.k8s_namespace](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/resource_definition) | resource |
 | [humanitec_resource_definition_criteria.k8s_cluster_driver](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/resource_definition_criteria) | resource |

--- a/modules/base/humanitec.tf
+++ b/modules/base/humanitec.tf
@@ -1,11 +1,25 @@
 # Humanitec resource definition to connect the cluster to Humanitec
 
+resource "humanitec_resource_account" "cluster_account" {
+  id   = var.cluster_name
+  name = var.cluster_name
+  type = "azure"
+
+  credentials = jsonencode({
+    "appId" : azuread_service_principal.humanitec.client_id,
+    "displayName" : azuread_application.main.display_name,
+    "password" : azuread_service_principal_password.humanitec.value,
+    "tenant" : azuread_service_principal.humanitec.application_tenant_id
+  })
+}
+
 resource "humanitec_resource_definition" "k8s_cluster_driver" {
   driver_type = "humanitec/k8s-cluster-aks"
   id          = var.cluster_name
   name        = var.cluster_name
   type        = "k8s-cluster"
 
+  driver_account = humanitec_resource_account.cluster_account.id
   driver_inputs = {
     values_string = jsonencode({
       "loadbalancer" : azurerm_public_ip.ingress.ip_address
@@ -13,14 +27,6 @@ resource "humanitec_resource_definition" "k8s_cluster_driver" {
       "resource_group" : azurerm_resource_group.main.name
       "subscription_id" : var.subscription_id,
       "server_app_id" : data.azuread_service_principal.aks.client_id
-    })
-    secrets_string = jsonencode({
-      "credentials" = {
-        "appId" : azuread_service_principal.humanitec.client_id,
-        "displayName" : azuread_application.main.display_name,
-        "password" : azuread_service_principal_password.humanitec.value,
-        "tenant" : azuread_service_principal.humanitec.application_tenant_id
-      }
     })
   }
 }


### PR DESCRIPTION
Use a resource account instead of injecting the credentials directly into the driver.

This prepares us for using temporary credentials in the future.