### PR TITLE
Update ingress.tf - 4.10.1 + runAsNonRoot

### DIFF
--- a/modules/base/README.md
+++ b/modules/base/README.md
@@ -55,7 +55,6 @@ Module that provides the reference architecture.
 | [humanitec_resource_definition_criteria.default_postgres](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/resource_definition_criteria) | resource |
 | [humanitec_resource_definition_criteria.k8s_cluster_driver](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/resource_definition_criteria) | resource |
 | [humanitec_resource_definition_criteria.k8s_namespace](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/resource_definition_criteria) | resource |
-| [kubernetes_namespace.ingress_nginx](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
 | [random_string.name_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
 | [azuread_client_config.current](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/client_config) | data source |
 | [azuread_service_principal.aks](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/service_principal) | data source |

--- a/modules/base/README.md
+++ b/modules/base/README.md
@@ -55,6 +55,7 @@ Module that provides the reference architecture.
 | [humanitec_resource_definition_criteria.default_postgres](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/resource_definition_criteria) | resource |
 | [humanitec_resource_definition_criteria.k8s_cluster_driver](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/resource_definition_criteria) | resource |
 | [humanitec_resource_definition_criteria.k8s_namespace](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/resource_definition_criteria) | resource |
+| [kubernetes_namespace.ingress_nginx](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
 | [random_string.name_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
 | [azuread_client_config.current](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/client_config) | data source |
 | [azuread_service_principal.aks](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/service_principal) | data source |

--- a/modules/base/ingress.tf
+++ b/modules/base/ingress.tf
@@ -15,7 +15,7 @@ resource "helm_release" "ingress_nginx" {
   repository       = "https://kubernetes.github.io/ingress-nginx"
 
   chart   = "ingress-nginx"
-  version = "4.10.0"
+  version = "4.10.1"
   wait    = true
   timeout = 600
 
@@ -53,6 +53,41 @@ resource "helm_release" "ingress_nginx" {
     type  = "string"
     name  = "controller.minAvailable"
     value = var.ingress_nginx_min_unavailable
+  }
+
+  set {
+    name  = "controller.containerSecurityContext.runAsUser"
+    value = 101
+  }
+
+  set {
+    name  = "controller.containerSecurityContext.runAsGroup"
+    value = 101
+  }
+
+  set {
+    name  = "controller.containerSecurityContext.allowPrivilegeEscalation"
+    value = false
+  }
+
+  set {
+    name  = "controller.containerSecurityContext.readOnlyRootFilesystem"
+    value = false
+  }
+
+  set {
+    name  = "controller.containerSecurityContext.runAsNonRoot"
+    value = true
+  }
+
+  set_list {
+    name  = "controller.containerSecurityContext.capabilities.drop"
+    value = ["ALL"]
+  }
+
+  set_list {
+    name  = "controller.containerSecurityContext.capabilities.add"
+    value = ["NET_BIND_SERVICE"]
   }
 
   depends_on = [module.azure_aks.node_resource_group]

--- a/modules/base/ingress.tf
+++ b/modules/base/ingress.tf
@@ -8,10 +8,19 @@ resource "azurerm_public_ip" "ingress" {
 
 # Ingress controller
 
+resource "kubernetes_namespace" "ingress_nginx" {
+  metadata {
+    labels = {
+      "pod-security.kubernetes.io/enforce" = "restricted"
+    }
+
+    name = "ingress-nginx"
+  }
+}
+
 resource "helm_release" "ingress_nginx" {
   name             = "ingress-nginx"
-  namespace        = "ingress-nginx"
-  create_namespace = true
+  namespace        = kubernetes_namespace.ingress_nginx.metadata.0.name
   repository       = "https://kubernetes.github.io/ingress-nginx"
 
   chart   = "ingress-nginx"

--- a/modules/base/ingress.tf
+++ b/modules/base/ingress.tf
@@ -8,19 +8,10 @@ resource "azurerm_public_ip" "ingress" {
 
 # Ingress controller
 
-resource "kubernetes_namespace" "ingress_nginx" {
-  metadata {
-    labels = {
-      "pod-security.kubernetes.io/enforce" = "restricted"
-    }
-
-    name = "ingress-nginx"
-  }
-}
-
 resource "helm_release" "ingress_nginx" {
   name             = "ingress-nginx"
-  namespace        = kubernetes_namespace.ingress_nginx.metadata.0.name
+  namespace        = "ingress-nginx"
+  create_namespace = true
   repository       = "https://kubernetes.github.io/ingress-nginx"
 
   chart   = "ingress-nginx"


### PR DESCRIPTION
Nginx Ingress updates:
- Nginx Ingress 4.10.1: https://github.com/kubernetes/ingress-nginx/releases/tag/helm-chart-4.10.1
- `runAsNonRoot` like we have in GCP ref arch: https://github.com/humanitec-architecture/reference-architecture-gcp/blob/main/modules/gke/helm_ingress.tf#L19C3-L52C4
- PSS restricted