### PR TITLE
fix: set account type to azure-identity

### DIFF
--- a/modules/base/humanitec.tf
+++ b/modules/base/humanitec.tf
@@ -3,7 +3,7 @@
 resource "humanitec_resource_account" "cluster_account" {
   id   = var.cluster_name
   name = var.cluster_name
-  type = "azure"
+  type = "azure-identity"
 
   credentials = jsonencode({
     "azure_identity_tenant_id" : azuread_service_principal.humanitec.application_tenant_id


### PR DESCRIPTION
Fixes: #18 with the correct account type for the Azure service principal see the docs here https://developer.humanitec.com/platform-orchestrator/reference/cloud-account-types/