### PR TITLE
Update free trial link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ By default, the following will be provisioned:
 
 ### Prerequisites
 
-* A Humanitec account with the `Administrator` role in an Organization. Get a [free trial](https://humanitec.com/free-trial?utm_source=github&utm_medium=referral&utm_campaign=azure_refarch_repo) if you are just starting.
+* A Humanitec account with the `Administrator` role in an Organization. Get a [free trial](https://app.humanitec.io/auth/signup) if you are just starting.
 * An Azure account
 * [Azure CLI](https://docs.microsoft.com/cli/azure/install-azure-cli) installed locally
 * [kubelogin](https://azure.github.io/kubelogin/install.html) installed locally


### PR DESCRIPTION
This PR updates the Hubspot based link https://humanitec.com/free-trial with https://app.humanitec.io/auth/signup in the main README.

Note: the new target does not support the UTMs anymore, they can therefore be dropped.