### PR TITLE
Fix: Adjust module source to support terraform 1.10.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Once you are finished with the reference architecture, you can remove all provis
 |------|--------|---------|
 | base | ./modules/base | n/a |
 | github | ./modules/github | n/a |
-| github\_app | github.com/humanitec-architecture/shared-terraform-modules | v2024-06-12//modules/github-app |
+| github\_app | github.com/humanitec-architecture/shared-terraform-modules//modules/github-app | v2024-06-12 |
 | portal\_backstage | ./modules/portal-backstage | n/a |
 
 ### Resources

--- a/main.tf
+++ b/main.tf
@@ -53,7 +53,7 @@ locals {
 module "github_app" {
   count = var.with_backstage ? 1 : 0
 
-  source = "github.com/humanitec-architecture/shared-terraform-modules?ref=v2024-06-12//modules/github-app"
+  source = "github.com/humanitec-architecture/shared-terraform-modules//modules/github-app?ref=v2024-06-12"
 
   credentials_file = "${path.module}/${local.github_app_credentials_file}"
 }

--- a/modules/base/README.md
+++ b/modules/base/README.md
@@ -30,8 +30,8 @@ Module that provides the reference architecture.
 | Name | Source | Version |
 |------|--------|---------|
 | azure\_aks | Azure/aks/azurerm | ~> 7 |
-| default\_mysql | github.com/humanitec-architecture/resource-packs-in-cluster | v2024-11-05//humanitec-resource-defs/mysql/basic |
-| default\_postgres | github.com/humanitec-architecture/resource-packs-in-cluster | v2024-11-05//humanitec-resource-defs/postgres/basic |
+| default\_mysql | github.com/humanitec-architecture/resource-packs-in-cluster//humanitec-resource-defs/mysql/basic | v2024-11-05 |
+| default\_postgres | github.com/humanitec-architecture/resource-packs-in-cluster//humanitec-resource-defs/postgres/basic | v2024-11-05 |
 
 ### Resources
 

--- a/modules/base/humanitec.tf
+++ b/modules/base/humanitec.tf
@@ -54,7 +54,7 @@ resource "humanitec_resource_definition_criteria" "k8s_namespace" {
 # in-cluster postgres
 
 module "default_postgres" {
-  source = "github.com/humanitec-architecture/resource-packs-in-cluster?ref=v2024-11-05//humanitec-resource-defs/postgres/basic"
+  source = "github.com/humanitec-architecture/resource-packs-in-cluster//humanitec-resource-defs/postgres/basic?ref=v2024-11-05"
 
   prefix = "default-"
 }
@@ -65,7 +65,7 @@ resource "humanitec_resource_definition_criteria" "default_postgres" {
 }
 
 module "default_mysql" {
-  source = "github.com/humanitec-architecture/resource-packs-in-cluster?ref=v2024-11-05//humanitec-resource-defs/mysql/basic"
+  source = "github.com/humanitec-architecture/resource-packs-in-cluster//humanitec-resource-defs/mysql/basic?ref=v2024-11-05"
 
   prefix = "default-"
 }

--- a/modules/portal-backstage/README.md
+++ b/modules/portal-backstage/README.md
@@ -16,8 +16,8 @@
 
 | Name | Source | Version |
 |------|--------|---------|
-| backstage\_postgres | github.com/humanitec-architecture/resource-packs-in-cluster | v2024-11-05//humanitec-resource-defs/postgres/basic |
-| portal\_backstage | github.com/humanitec-architecture/shared-terraform-modules | v2024-06-12//modules/portal-backstage |
+| backstage\_postgres | github.com/humanitec-architecture/resource-packs-in-cluster//humanitec-resource-defs/postgres/basic | v2024-11-05 |
+| portal\_backstage | github.com/humanitec-architecture/shared-terraform-modules//modules/portal-backstage | v2024-06-12 |
 
 ### Resources
 

--- a/modules/portal-backstage/main.tf
+++ b/modules/portal-backstage/main.tf
@@ -20,7 +20,7 @@ locals {
 }
 
 module "portal_backstage" {
-  source = "github.com/humanitec-architecture/shared-terraform-modules?ref=v2024-06-12//modules/portal-backstage"
+  source = "github.com/humanitec-architecture/shared-terraform-modules//modules/portal-backstage?ref=v2024-06-12"
 
   cloud_provider = "azure"
 
@@ -49,7 +49,7 @@ locals {
 # in-cluster postgres
 
 module "backstage_postgres" {
-  source = "github.com/humanitec-architecture/resource-packs-in-cluster?ref=v2024-11-05//humanitec-resource-defs/postgres/basic"
+  source = "github.com/humanitec-architecture/resource-packs-in-cluster//humanitec-resource-defs/postgres/basic?ref=v2024-11-05"
 
   prefix = local.res_def_prefix
 }


### PR DESCRIPTION
This PR adjusts the `source` format in `modules` referencing other GitHub repositories. The current format breaks `terraform init` for `terraform` clients of the current version `1.10.x`.

The new format is compatible across older and newer versions (tested `1.5.7`, `1.9.2`, and `1.10.4`) as well as the current OpenTofu version `1.9.0`.